### PR TITLE
Fix Remote Command Execution Vulnerability

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var debug = require('debug')('strider-git');
-var exec = require('child_process').exec;
+var execFile = require('child_process').execFile;
 var shellescape = require('shell-escape');
 
 module.exports = {
@@ -148,7 +148,7 @@ function getBranches(config, privkey, done) {
       processBranches(stdout, done);
     });
   } else {
-    exec(`git ls-remote -h ${httpUrl(config)[0]}`, function (err, stdout) {
+    execFile('git', ['ls-remote', '-h', `${httpUrl(config)[0]}`], function (err, stdout) {
       if (err) return done(err);
       processBranches(stdout, done);
     });


### PR DESCRIPTION
### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._


#### Bounty URL: https://www.huntr.dev/app/bounties/open/1-npm-strider-git

### ⚙️ Description *

The strider-git module suffers from a command injection (could result in remote command execution) caused by the lack of sanitizing the input arguments before executing it.

### 💻 Technical Description *

In the provided PoC the command execution occurred in [L151](https://github.com/Strider-CD/strider-git/blob/master/lib/index.js#L151).

The occurrence of this vulnerability is caused due to the usage of the `exec()` function. In general, `exec` allows us to execute more than one command on a shell. When using `exec`, if we need to pass arguments to the command, they should be part of the whole command string. Which in this case is what cause the vulnerability while in `execFile` the provided input is taken as arguments rather than command itself. So I replaced the `exec()` command with `execFile()` which will fix the vulnerability

```diff
- var exec = require('child_process').exec;
+ var execFile = require('child_process').execFile;
-  exec(`git ls-remote -h ${httpUrl(config)[0]}`, function (err, stdout) {
+ execFile('git', ['ls-remote', '-h', `${httpUrl(config)[0]}`], function (err, stdout) {
```

### 🐛 Proof of Concept (PoC) *

```javascript
// poc.js
var git = require("strider-git/lib");
git.getBranches({auth:{type:'ssaas;touch HACKED; ', privkey:'sss'}, url:'http://sss'}, '', function(){})
```

![image](https://user-images.githubusercontent.com/17072444/85186507-15775200-b25f-11ea-8ab1-659a8c524937.png)



### 🔥 Proof of Fix (PoF) *
```bash
npm i strider-git # Install affected module
node poc.js #  Run the PoC
```

![image](https://user-images.githubusercontent.com/17072444/85186531-3770d480-b25f-11ea-894c-3842b3872ec6.png)


### 👍 User Acceptance Testing (UAT)

```
w'h'o'am'i
w\ho\am\i
/\b\i\n/////s\h
cat /etc/passwd
/???/??t /???/p??s??
something%0Acat%20/etc/passwd

```
